### PR TITLE
Fixed timeout unit time

### DIFF
--- a/YLTCPBroadcaster/YLTCPSocket.m
+++ b/YLTCPBroadcaster/YLTCPSocket.m
@@ -122,7 +122,7 @@ const NSUInteger kYLTCPSocketDefaultTimeoutInSeconds = 2;
       // Set the timeout interval
       double timeoutDecimal = (NSInteger)timeout;
       tv.tv_sec             = timeoutDecimal;
-      tv.tv_usec            = (timeout - timeoutDecimal) * 1000;
+      tv.tv_usec            = (timeout - timeoutDecimal) * 1000 * 1000;
 
       FD_ZERO(&fdset);
       FD_SET(sockfd, &fdset);


### PR DESCRIPTION
The tv_usec is defined in Microsecond (0.000001). 
Currently it is calculated as Millisecond (0.001).

http://pubs.opengroup.org/onlinepubs/007908799/xsh/systime.h.html